### PR TITLE
Feature/better handle k1 public key format on signing

### DIFF
--- a/eosiojavasoftkeysignatureprovider/build.gradle
+++ b/eosiojavasoftkeysignatureprovider/build.gradle
@@ -34,7 +34,7 @@ configurations.all {
 
 def libraryGroupId = 'one.block'
 def libraryArtifactId = 'eosiojavasoftkeysignatureprovider'
-def libraryVersion = '0.1.0'
+def libraryVersion = '0.1.1'
 
 task sourcesJar(type: Jar, dependsOn: classes){
     classifier = 'sources'

--- a/eosiojavasoftkeysignatureprovider/src/main/java/one/block/eosiosoftkeysignatureprovider/SoftKeySignatureProviderImpl.java
+++ b/eosiojavasoftkeysignatureprovider/src/main/java/one/block/eosiosoftkeysignatureprovider/SoftKeySignatureProviderImpl.java
@@ -33,7 +33,6 @@ import java.util.Set;
  * an in-memory private key generated with the secp256r1, prime256v1, or secp256k1 algorithms.  This
  * implementation is NOT secure and should only be used for educational purposes.  It is NOT
  * advisable to store private keys outside of secure devices like TEE's and SE's.
- *
  */
 public class SoftKeySignatureProviderImpl implements ISignatureProvider {
 
@@ -41,12 +40,6 @@ public class SoftKeySignatureProviderImpl implements ISignatureProvider {
      * Keep a Set (Unique) of private keys in PEM format
      */
     private Set<String> keys = new LinkedHashSet<>();
-
-    /**
-     * Whether getAvailableKeys should return WIF legacy format for key generated with secp256k1
-     * algorithm.  This for of the key is prefaced with "EOS" instead of "PUB_K1_".
-     */
-    private boolean returnLegacyFormatForK1;
 
     /**
      * Maximum number of times the signature provider should try to create a canonical signature
@@ -68,6 +61,12 @@ public class SoftKeySignatureProviderImpl implements ISignatureProvider {
      * Signum to convert a negative value to a positive Big Integer
      */
     private static final int BIG_INTEGER_POSITIVE = 1;
+
+    /**
+     * Place holder for Whether getAvailableKeys should return WIF legacy format for key generated with secp256k1
+     * algorithm.  This for of the key is prefaced with "EOS" instead of "PUB_K1_".
+     */
+    private static final boolean DEFAULT_WHETHER_USING_K1_LEGACY_FORMAT = false;
 
     /**
      * Import private key into softkey signature provider.  Private key is stored in memory.
@@ -145,7 +144,7 @@ public class SoftKeySignatureProviderImpl implements ISignatureProvider {
                 for (String key : keys) {
                     PEMProcessor availableKeyProcessor = new PEMProcessor(key);
                     //Extract public key in PEM format from inner private key
-                    String innerPublicKeyPEM = availableKeyProcessor.extractPEMPublicKeyFromPrivateKey(this.returnLegacyFormatForK1);
+                    String innerPublicKeyPEM = availableKeyProcessor.extractPEMPublicKeyFromPrivateKey(DEFAULT_WHETHER_USING_K1_LEGACY_FORMAT);
 
                     // Convert input public key to PEM format for comparision
                     String inputPublicKeyPEM = EOSFormatter.convertEOSPublicKeyToPEMFormat(inputPublicKey);
@@ -187,7 +186,7 @@ public class SoftKeySignatureProviderImpl implements ISignatureProvider {
                     // Format Signature
                     signatures.add(signature);
                     break;
-                }  catch (EOSFormatterError eosFormatterError) {
+                } catch (EOSFormatterError eosFormatterError) {
                     // In theory, Non-canonical error only happened with K1 key
                     if (eosFormatterError.getCause() instanceof EosFormatterSignatureIsNotCanonicalError && curve == AlgorithmEmployed.SECP256K1) {
                         // Try to sign again until MAX_NOT_CANONICAL_RE_SIGN is reached or get a canonical signature
@@ -202,6 +201,15 @@ public class SoftKeySignatureProviderImpl implements ISignatureProvider {
         return new EosioTransactionSignatureResponse(serializedTransaction, signatures, null);
     }
 
+    /**
+     * Gets available keys from signature provider <br> Check createSignatureRequest() flow in
+     * "complete workflow" for more detail of how the method is used.
+     * <p>
+     * Public key of SECP256K1 has 2 types of format in EOSIO which are "EOS" and "PUB_K1_" so this method return 2 public keys in both format for SECP256K1 and 1 public key for SECP256R1.
+     *
+     * @return the available keys of signature provider in EOS format
+     * @throws GetAvailableKeysError thrown if there are any exceptions during the get available keys process.
+     */
     @Override
     public @NotNull List<String> getAvailableKeys() throws GetAvailableKeysError {
         List<String> availableKeys = new ArrayList<>();
@@ -212,31 +220,28 @@ public class SoftKeySignatureProviderImpl implements ISignatureProvider {
         try {
             for (String key : this.keys) {
                 PEMProcessor processor = new PEMProcessor(key);
-                availableKeys.add(processor.extractEOSPublicKeyFromPrivateKey(this.returnLegacyFormatForK1));
+                AlgorithmEmployed curve = processor.getAlgorithm();
+
+                switch (curve) {
+                    case SECP256R1:
+                        availableKeys.add(processor.extractEOSPublicKeyFromPrivateKey(false));
+                        break;
+
+                    case SECP256K1:
+                        // Non legacy
+                        availableKeys.add(processor.extractEOSPublicKeyFromPrivateKey(false));
+                        // legacy
+                        availableKeys.add(processor.extractEOSPublicKeyFromPrivateKey(true));
+                        break;
+
+                    default:
+                        throw new GetAvailableKeysError(SoftKeySignatureErrorConstants.GET_KEYS_KEY_FORMAT_NOT_SUPPORTED);
+                }
             }
         } catch (PEMProcessorError pemProcessorError) {
             throw new GetAvailableKeysError(SoftKeySignatureErrorConstants.CONVERT_TO_PEM_EMPTY_ERROR, pemProcessorError);
         }
 
         return availableKeys;
-    }
-
-    /**
-     * Whether getAvailableKeys should return WIF legacy format for key generated with secp256k1
-     * algorithm.  This for of the key is prefaced with "EOS" instead of "PUB_K1_".     *
-     * @return Whether getAvailableKeys return WIF legacy format for K1 key
-     */
-    public boolean isReturnLegacyFormatForK1() {
-        return returnLegacyFormatForK1;
-    }
-
-    /**
-     * Set returnLegacyFormatForK1 to true to get WIF Legacy format for secp256k1 generated public
-     * key returned from method getAvailableKeys().
-     *
-     * @param returnLegacyFormatForK1 true for getting WIF Legacy format of K1 public key on getAvailableKey
-     */
-    public void setReturnLegacyFormatForK1(boolean returnLegacyFormatForK1) {
-        this.returnLegacyFormatForK1 = returnLegacyFormatForK1;
     }
 }

--- a/eosiojavasoftkeysignatureprovider/src/main/java/one/block/eosiosoftkeysignatureprovider/error/SoftKeySignatureErrorConstants.java
+++ b/eosiojavasoftkeysignatureprovider/src/main/java/one/block/eosiosoftkeysignatureprovider/error/SoftKeySignatureErrorConstants.java
@@ -1,5 +1,7 @@
 package one.block.eosiosoftkeysignatureprovider.error;
 
+import one.block.eosiosoftkeysignatureprovider.SoftKeySignatureProviderImpl;
+
 /**
  * Error constants that pertain to the signing of transactions using the softkey signature provider
  * implementation {@link one.block.eosiosoftkeysignatureprovider.SoftKeySignatureProviderImpl}
@@ -59,4 +61,8 @@ public class SoftKeySignatureErrorConstants {
      * Describes a failure to format the signature that must accompany a signed transaction.
      */
     public static final String SIGN_TRANS_FORMAT_SIGNATURE_ERROR = "Error when trying to format signature.";
+    /**
+     * Key curve is not supported in key transformation on {@link SoftKeySignatureProviderImpl#getAvailableKeys()}
+     */
+    public static final String GET_KEYS_KEY_FORMAT_NOT_SUPPORTED = "Error on trying to transform key in getAvailableKey(): Algorithm is not supported!";
 }

--- a/eosiojavasoftkeysignatureprovider/src/test/java/one/block/eosiojavasoftkeysignatureprovider/SoftKeySignatureProviderImplTest.java
+++ b/eosiojavasoftkeysignatureprovider/src/test/java/one/block/eosiojavasoftkeysignatureprovider/SoftKeySignatureProviderImplTest.java
@@ -65,37 +65,18 @@ public class SoftKeySignatureProviderImplTest {
     }
 
     @Test
-    public void importKeyK1LegacyTest() {
-        String privateKeyEOS = "5JKVeYzRs42DpnHU1rUeJHPZyXb1pCdhyayx7FD2qKHV63F71zU";
-        String publicKeyEOS = "EOS8CbY5PhQZGF2gzPKRBaNG4YzB4AwpmfnDcVZMSPZTqQMiGxPbF";
-        SoftKeySignatureProviderImpl provider = new SoftKeySignatureProviderImpl();
-
-        try {
-            provider.importKey(privateKeyEOS);
-            provider.setReturnLegacyFormatForK1(true);
-            List<String> keys = provider.getAvailableKeys();
-            assertEquals(1, keys.size());
-            assertEquals(publicKeyEOS, keys.get(0));
-        } catch (ImportKeyError importKeyError) {
-            importKeyError.printStackTrace();
-            fail("Should not throw error!!!!");
-        } catch (GetAvailableKeysError getAvailableKeysError) {
-            getAvailableKeysError.printStackTrace();
-            fail("Should not throw error!!!");
-        }
-    }
-
-    @Test
     public void importKeyK1Test() {
         String privateKeyEOS = "5JKVeYzRs42DpnHU1rUeJHPZyXb1pCdhyayx7FD2qKHV63F71zU";
+        String publicKeyEOSLegacy = "EOS8CbY5PhQZGF2gzPKRBaNG4YzB4AwpmfnDcVZMSPZTqQMiGxPbF";
         String publicKeyEOS = "PUB_K1_8CbY5PhQZGF2gzPKRBaNG4YzB4AwpmfnDcVZMSPZTqQMn1uFhB";
         SoftKeySignatureProviderImpl provider = new SoftKeySignatureProviderImpl();
 
         try {
             provider.importKey(privateKeyEOS);
             List<String> keys = provider.getAvailableKeys();
-            assertEquals(1, keys.size());
-            assertEquals(publicKeyEOS, keys.get(0));
+            assertEquals(2, keys.size());
+            assertTrue(keys.contains(publicKeyEOS));
+            assertTrue(keys.contains(publicKeyEOSLegacy));
         } catch (ImportKeyError importKeyError) {
             importKeyError.printStackTrace();
             fail("Should not throw error!!!!");
@@ -111,6 +92,7 @@ public class SoftKeySignatureProviderImplTest {
         String privateKeyR1EOS = "PVT_R1_g6vV9tiGqN3LkhD53pVUbxDn76PuVeR6XfmJzrnLR3PbGWLys";
         String publicKeyR1EOS = "PUB_R1_71AYFp3Aasa2od6bwmXEQ13MMfqv4wuJwCRx1Z1dbRifrQEqZt";
         String publicKeyK1EOS = "PUB_K1_8CbY5PhQZGF2gzPKRBaNG4YzB4AwpmfnDcVZMSPZTqQMn1uFhB";
+        String publicKeyK1EOSLegacy = "EOS8CbY5PhQZGF2gzPKRBaNG4YzB4AwpmfnDcVZMSPZTqQMiGxPbF";
 
         SoftKeySignatureProviderImpl provider = new SoftKeySignatureProviderImpl();
 
@@ -124,9 +106,10 @@ public class SoftKeySignatureProviderImplTest {
 
         try {
             List<String> keys = provider.getAvailableKeys();
-            assertEquals(2, keys.size());
-            assertEquals(publicKeyK1EOS, keys.get(0));
-            assertEquals(publicKeyR1EOS, keys.get(1));
+            assertEquals(3, keys.size());
+            assertTrue(keys.contains(publicKeyK1EOS));
+            assertTrue(keys.contains(publicKeyK1EOSLegacy));
+            assertTrue(keys.contains(publicKeyR1EOS));
         } catch (GetAvailableKeysError getAvailableKeysError) {
             getAvailableKeysError.printStackTrace();
             fail("Should not throw error!!!");
@@ -167,65 +150,65 @@ public class SoftKeySignatureProviderImplTest {
     public void signTransactionTestMultipleKeys() {
         // R1 key test
         List<String[]> keyPairs = new ArrayList<>();
-        keyPairs.add(new String[] {"PVT_R1_27XFnmZj3gYEeeSy4fy5PoqoP63n94nhTAyFMcuJGAV9b5cqyC", "PUB_R1_5AvUuRssyb7Z2HgNHVofX5heUV5dk8Gni1BGNMzMRCGbhdhBbu"});
-        keyPairs.add(new String[] {"PVT_R1_GrfEfbv5at9kbeHcGagQmvbFLdm6jqEpgE1wsGbrfbZNjpVgT", "PUB_R1_4ztaVy8L9zbmzTdpfq5GcaFYwGwXTNmN3qW7qcgHMmfUZhpzQQ"});
-        keyPairs.add(new String[] {"PVT_R1_wCpPsaY9o8NU9ZsuwaYVQUDkCfj1aWJZGVcmMM6XyYHJVqvqp", "PUB_R1_5xawnnr3mWayv2wkiqBGWqu4RQLNJffLSXHiL3BofdY7ortMy4"});
-        keyPairs.add(new String[] {"PVT_R1_2sXhBwN8hCLSWRxxfZg6hqwGymKSudtQ7Qa5wUWyuW54E1Gd7P", "PUB_R1_6UYnNnXv2CutCtTLgCQxJbHBeWDG3JZaSQJK9tQ7K3JUdzXw9p"});
-        keyPairs.add(new String[] {"PVT_R1_2fJmPgaik4rUeU1NDchQjnSPkQkga4iKzdK5hhdbKf2PQFJ57t", "PUB_R1_5MVdX3uzs6qDHUYpdSksZFc5rAu5P4ba6MDaySuYyzQqmCw96Q"});
-        keyPairs.add(new String[] {"PVT_R1_2FBMJryipxmAeiwFYXvBTRhX1y5tdepDYBjCm4VqBWcsmdy1xD", "PUB_R1_5qjeAbU6mUM4PLRQBw8V4kxuc5pAjnJFpcMrdZmHF6L6uH57dk"});
-        keyPairs.add(new String[] {"PVT_R1_2tjkXAnQPi5Jte8H5SihUQDRnJDPTny5hoiWxxeKm7uC1osiet", "PUB_R1_5BpFt4f1PXzvU2SVmwZdtCiFWbwDRHPzh8Fiao8PCd1R17pH5S"});
-        keyPairs.add(new String[] {"PVT_R1_onDM2GMv8D9E7tXuZtGtyEGdLr5TWBuE6weLBwB9hC3NNao6", "PUB_R1_85V3FDScTPvPKhQLQMhrqrQE4xnrqWbZVor5B2LC1qwuJaL15p"});
-        keyPairs.add(new String[] {"PVT_R1_jW6MUBQWWmy8Zj1nhtGuMSZaPMH2FXwyJYBkJKndPBRCFPAiH", "PUB_R1_8H8Gwa6rwETdZsKWV6r8Ec9MCa4eVU6PKjDWxShB4EjxRtw5mb"});
-        keyPairs.add(new String[] {"PVT_R1_2fX6RwwREC8mVCvX31C5ivCsVAGbQ4waX3wEmiRQoamsGQm2cV", "PUB_R1_5tTLGveJ7TndwDEk8mbw6wEYxNoRmUSrSLjqRdahZWmF1r93QP"});
-        keyPairs.add(new String[] {"PVT_R1_2bmerckTyLpK5Z9gaoAHbHWhRBHEC3b8uxdqnFciK9tgx7RnL1", "PUB_R1_84ra3upayTtazvWHJQUgfcJ6hTKYtyUJfckx8qXeRi2kRoxbSJ"});
-        keyPairs.add(new String[] {"PVT_R1_2i3AZiJEQxUejHL5c8TheCXdB4yuRacJkVkdR5PxLqDwcax6mT", "PUB_R1_8V7dPunExH1bWnD88gduac71tbjW1CSPuaaUVhJwZG6yF544xE"});
-        keyPairs.add(new String[] {"PVT_R1_2HXMYeSqWGqPhUbK8FLzfxJzMV9dPT7ZXFJi9Q2DLkSN1dNwzp", "PUB_R1_7QKfB2nBJJPsUDoBBJVRYV9ak1egBH6dDDGPgvT83zUs1AvQfU"});
+        keyPairs.add(new String[]{"PVT_R1_27XFnmZj3gYEeeSy4fy5PoqoP63n94nhTAyFMcuJGAV9b5cqyC", "PUB_R1_5AvUuRssyb7Z2HgNHVofX5heUV5dk8Gni1BGNMzMRCGbhdhBbu"});
+        keyPairs.add(new String[]{"PVT_R1_GrfEfbv5at9kbeHcGagQmvbFLdm6jqEpgE1wsGbrfbZNjpVgT", "PUB_R1_4ztaVy8L9zbmzTdpfq5GcaFYwGwXTNmN3qW7qcgHMmfUZhpzQQ"});
+        keyPairs.add(new String[]{"PVT_R1_wCpPsaY9o8NU9ZsuwaYVQUDkCfj1aWJZGVcmMM6XyYHJVqvqp", "PUB_R1_5xawnnr3mWayv2wkiqBGWqu4RQLNJffLSXHiL3BofdY7ortMy4"});
+        keyPairs.add(new String[]{"PVT_R1_2sXhBwN8hCLSWRxxfZg6hqwGymKSudtQ7Qa5wUWyuW54E1Gd7P", "PUB_R1_6UYnNnXv2CutCtTLgCQxJbHBeWDG3JZaSQJK9tQ7K3JUdzXw9p"});
+        keyPairs.add(new String[]{"PVT_R1_2fJmPgaik4rUeU1NDchQjnSPkQkga4iKzdK5hhdbKf2PQFJ57t", "PUB_R1_5MVdX3uzs6qDHUYpdSksZFc5rAu5P4ba6MDaySuYyzQqmCw96Q"});
+        keyPairs.add(new String[]{"PVT_R1_2FBMJryipxmAeiwFYXvBTRhX1y5tdepDYBjCm4VqBWcsmdy1xD", "PUB_R1_5qjeAbU6mUM4PLRQBw8V4kxuc5pAjnJFpcMrdZmHF6L6uH57dk"});
+        keyPairs.add(new String[]{"PVT_R1_2tjkXAnQPi5Jte8H5SihUQDRnJDPTny5hoiWxxeKm7uC1osiet", "PUB_R1_5BpFt4f1PXzvU2SVmwZdtCiFWbwDRHPzh8Fiao8PCd1R17pH5S"});
+        keyPairs.add(new String[]{"PVT_R1_onDM2GMv8D9E7tXuZtGtyEGdLr5TWBuE6weLBwB9hC3NNao6", "PUB_R1_85V3FDScTPvPKhQLQMhrqrQE4xnrqWbZVor5B2LC1qwuJaL15p"});
+        keyPairs.add(new String[]{"PVT_R1_jW6MUBQWWmy8Zj1nhtGuMSZaPMH2FXwyJYBkJKndPBRCFPAiH", "PUB_R1_8H8Gwa6rwETdZsKWV6r8Ec9MCa4eVU6PKjDWxShB4EjxRtw5mb"});
+        keyPairs.add(new String[]{"PVT_R1_2fX6RwwREC8mVCvX31C5ivCsVAGbQ4waX3wEmiRQoamsGQm2cV", "PUB_R1_5tTLGveJ7TndwDEk8mbw6wEYxNoRmUSrSLjqRdahZWmF1r93QP"});
+        keyPairs.add(new String[]{"PVT_R1_2bmerckTyLpK5Z9gaoAHbHWhRBHEC3b8uxdqnFciK9tgx7RnL1", "PUB_R1_84ra3upayTtazvWHJQUgfcJ6hTKYtyUJfckx8qXeRi2kRoxbSJ"});
+        keyPairs.add(new String[]{"PVT_R1_2i3AZiJEQxUejHL5c8TheCXdB4yuRacJkVkdR5PxLqDwcax6mT", "PUB_R1_8V7dPunExH1bWnD88gduac71tbjW1CSPuaaUVhJwZG6yF544xE"});
+        keyPairs.add(new String[]{"PVT_R1_2HXMYeSqWGqPhUbK8FLzfxJzMV9dPT7ZXFJi9Q2DLkSN1dNwzp", "PUB_R1_7QKfB2nBJJPsUDoBBJVRYV9ak1egBH6dDDGPgvT83zUs1AvQfU"});
 
         for (String[] keyPair : keyPairs) {
-            this.signTransactionTestWithArgs(keyPair[0], keyPair[1], false);
+            this.signTransactionTestWithArgs(keyPair[0], keyPair[1]);
         }
 
         // K1 test in WIF test
         keyPairs = new ArrayList<>();
-        keyPairs.add(new String[] {"5KaUJmXMVc2FF1XMRAjCxmh5or2w6awq4SaGft7HfApJLGDroFd", "EOS5aYo7EthRA5XPG72ekWdbkjYPkk8o7ufLdDzoaj8QR9oshZAXW"});
-        keyPairs.add(new String[] {"5KaqhmASMEa6NeV6shfhq8AuYQa5r3xrxWvXB4SiSHwxaQeN2m6", "EOS65d2eTiu7TTdJrQ75JXdMxH657zBiT1Mqz4KhX3eyQAgQtpgf1"});
-        keyPairs.add(new String[] {"5K1GuwAFjjvFJsiQu2NHYoWWCV16xAxZ1LgUKw8WrF3T5Tg4556", "EOS8K6Jq3CFSgk3zBNAAsvY7a5p4vzyfxDQDprTwzQnUXnLEZBZAt"});
-        keyPairs.add(new String[] {"5KRdi3aCwQWSmX4nqNRbhYe6LLJz3xcxvEcWX141qarZGKqKKXQ", "EOS7ABgtG3CDJEPFfxqbvgLy77pxi2Ai3QJtQvrdhnduxEjjNzKVz"});
-        keyPairs.add(new String[] {"5KdTC3SHPDC3orkhvrDbDGvnT2NzR5kexkCnu5RkNbv9vaujSfp", "EOS6pr3Mz91u1Yv3Tkt7T7oqrT4w5nCmSuZCoPHwJCwGipoqaHBQ8"});
-        keyPairs.add(new String[] {"5K4VhWHSUJnwTaBhEx8LTECS4DewzRnizb2micRHfwwtnWmSMVx", "EOS8ajgEKL7eba36WpAhAiWp9jWxkP7ySzReFPVLkV7vNXKK6WhqA"});
-        keyPairs.add(new String[] {"5KFjmNrL2cx2SysfMhdFzGH9F7ERVfc85TogKeF55jS18VErhiA", "EOS7z5Co6Ynggq2ygsLWrn8sQ7kDvYiBTs5mFxWN8HvcxB35wyXUN"});
+        keyPairs.add(new String[]{"5KaUJmXMVc2FF1XMRAjCxmh5or2w6awq4SaGft7HfApJLGDroFd", "EOS5aYo7EthRA5XPG72ekWdbkjYPkk8o7ufLdDzoaj8QR9oshZAXW"});
+        keyPairs.add(new String[]{"5KaqhmASMEa6NeV6shfhq8AuYQa5r3xrxWvXB4SiSHwxaQeN2m6", "EOS65d2eTiu7TTdJrQ75JXdMxH657zBiT1Mqz4KhX3eyQAgQtpgf1"});
+        keyPairs.add(new String[]{"5K1GuwAFjjvFJsiQu2NHYoWWCV16xAxZ1LgUKw8WrF3T5Tg4556", "EOS8K6Jq3CFSgk3zBNAAsvY7a5p4vzyfxDQDprTwzQnUXnLEZBZAt"});
+        keyPairs.add(new String[]{"5KRdi3aCwQWSmX4nqNRbhYe6LLJz3xcxvEcWX141qarZGKqKKXQ", "EOS7ABgtG3CDJEPFfxqbvgLy77pxi2Ai3QJtQvrdhnduxEjjNzKVz"});
+        keyPairs.add(new String[]{"5KdTC3SHPDC3orkhvrDbDGvnT2NzR5kexkCnu5RkNbv9vaujSfp", "EOS6pr3Mz91u1Yv3Tkt7T7oqrT4w5nCmSuZCoPHwJCwGipoqaHBQ8"});
+        keyPairs.add(new String[]{"5K4VhWHSUJnwTaBhEx8LTECS4DewzRnizb2micRHfwwtnWmSMVx", "EOS8ajgEKL7eba36WpAhAiWp9jWxkP7ySzReFPVLkV7vNXKK6WhqA"});
+        keyPairs.add(new String[]{"5KFjmNrL2cx2SysfMhdFzGH9F7ERVfc85TogKeF55jS18VErhiA", "EOS7z5Co6Ynggq2ygsLWrn8sQ7kDvYiBTs5mFxWN8HvcxB35wyXUN"});
 
         for (String[] keyPair : keyPairs) {
-            this.signTransactionTestWithArgs(keyPair[0], keyPair[1], true);
+            this.signTransactionTestWithArgs(keyPair[0], keyPair[1]);
         }
 
         // K1 in new format test
         keyPairs = new ArrayList<>();
-        keyPairs.add(new String[] {"5JKVeYzRs42DpnHU1rUeJHPZyXb1pCdhyayx7FD2qKHV63F71zU", "PUB_K1_8CbY5PhQZGF2gzPKRBaNG4YzB4AwpmfnDcVZMSPZTqQMn1uFhB"});
-        keyPairs.add(new String[] {"5KW9dCerdNkGKa5Eis3tqmomFaK3FSwGyzShcFHFCxhSg3cYcda", "PUB_K1_6Lqa1KEfyCtMkf4aTUKsiFiRQ2QsfV6s7MrNe4AHL3xqtMYboc"});
-        keyPairs.add(new String[] {"5JfxDRNHhbG9buaYWM9BT2taCckeQo7CzCxBoCrm2GmGSzUegXJ", "PUB_K1_4zLmUratR7P1Bm8ofu1QywPYn9hYTdE4xK5J23n3kwA8jYyqnq"});
-        keyPairs.add(new String[] {"5JvqRMk6P7vHoScC3TKzEFBRYGdk1bej6pGGaToEjs9oaZUXm1a", "PUB_K1_5CfaiaeiyWWFXBYnAuYQXfLoTWxsxmycdG7gShvJoQCLRcGTqE"});
-        keyPairs.add(new String[] {"5JNMHnmTzKJTDHT5a7JCVU7TRz7As3GdeFdwgWRRgPBNW2buSLY", "PUB_K1_5RGwHXDwKugv8GZEFR1enxNEsoEKGGChwPUtEcEKKQbFmr5jgF"});
-        keyPairs.add(new String[] {"5J49cDDhbnwprVysd93yoogQXLh3Q37ge6iJPynjqHbzm9nozGy", "PUB_K1_8SpQXDt2ULK4v3Yx2u7qUp6zNaNT1gRwnrU5AJhM67Lk25tom8"});
-        keyPairs.add(new String[] {"5KXUHV94KCG2evdGQ1cNpUJ6PigS99mJBv2mvKNcjxQvXEee3c1", "PUB_K1_7BtR7o48FqfHhXgWtxifXGUPrg94HDHFPgTtgVG1vCA8KaxVgt"});
-        keyPairs.add(new String[] {"5K3otXd2RRQTZao5CYQXo2nHu2rC4VRN6LYQwyShxcfwNtsSgLo", "PUB_K1_8mNC41aAcXmZeoMZcRW6DUNSxs7AfZdfLnQ5WMbLPuzKPrk3wL"});
-        keyPairs.add(new String[] {"5JNtXpnqYQ1Fe3y7S3D7eVetprBuuf8Xzo89roo1QMPTB24kHkm", "PUB_K1_7FopBLaVh1uUQJ7qxFGCZgMttsBJKhXM9hbpFp83gmrUxYJLLE"});
-        keyPairs.add(new String[] {"5JM4fskPtJSwCqSb8Ax6vSYYRr7HwyrpnBxwfG3qr5mUFpMwgkA", "PUB_K1_77DjPHQtPRwXZKDtVvV93PsytUgevbqdPQcZpdPt2MwR541nX2"});
-        keyPairs.add(new String[] {"5K8EvWwTbQj7anhLWfr1K1mSMi78CD8YqHquei1gntJDStV8Zdh", "PUB_K1_8B89xwYNkcEEcwyC66LPptRAspCZ7SXy59BqsyoFeNyyq1sKfc"});
-        keyPairs.add(new String[] {"5J5DhKFZZqkNkTunWWbgrJNLDwZiK1vJk8Rd8nNL2fKPzLScn1x", "PUB_K1_58aKDkGmkHfswooj8nwhtrc42QrHVzUurnrhDR4Jr1rEk5uXRs"});
+        keyPairs.add(new String[]{"5JKVeYzRs42DpnHU1rUeJHPZyXb1pCdhyayx7FD2qKHV63F71zU", "PUB_K1_8CbY5PhQZGF2gzPKRBaNG4YzB4AwpmfnDcVZMSPZTqQMn1uFhB"});
+        keyPairs.add(new String[]{"5KW9dCerdNkGKa5Eis3tqmomFaK3FSwGyzShcFHFCxhSg3cYcda", "PUB_K1_6Lqa1KEfyCtMkf4aTUKsiFiRQ2QsfV6s7MrNe4AHL3xqtMYboc"});
+        keyPairs.add(new String[]{"5JfxDRNHhbG9buaYWM9BT2taCckeQo7CzCxBoCrm2GmGSzUegXJ", "PUB_K1_4zLmUratR7P1Bm8ofu1QywPYn9hYTdE4xK5J23n3kwA8jYyqnq"});
+        keyPairs.add(new String[]{"5JvqRMk6P7vHoScC3TKzEFBRYGdk1bej6pGGaToEjs9oaZUXm1a", "PUB_K1_5CfaiaeiyWWFXBYnAuYQXfLoTWxsxmycdG7gShvJoQCLRcGTqE"});
+        keyPairs.add(new String[]{"5JNMHnmTzKJTDHT5a7JCVU7TRz7As3GdeFdwgWRRgPBNW2buSLY", "PUB_K1_5RGwHXDwKugv8GZEFR1enxNEsoEKGGChwPUtEcEKKQbFmr5jgF"});
+        keyPairs.add(new String[]{"5J49cDDhbnwprVysd93yoogQXLh3Q37ge6iJPynjqHbzm9nozGy", "PUB_K1_8SpQXDt2ULK4v3Yx2u7qUp6zNaNT1gRwnrU5AJhM67Lk25tom8"});
+        keyPairs.add(new String[]{"5KXUHV94KCG2evdGQ1cNpUJ6PigS99mJBv2mvKNcjxQvXEee3c1", "PUB_K1_7BtR7o48FqfHhXgWtxifXGUPrg94HDHFPgTtgVG1vCA8KaxVgt"});
+        keyPairs.add(new String[]{"5K3otXd2RRQTZao5CYQXo2nHu2rC4VRN6LYQwyShxcfwNtsSgLo", "PUB_K1_8mNC41aAcXmZeoMZcRW6DUNSxs7AfZdfLnQ5WMbLPuzKPrk3wL"});
+        keyPairs.add(new String[]{"5JNtXpnqYQ1Fe3y7S3D7eVetprBuuf8Xzo89roo1QMPTB24kHkm", "PUB_K1_7FopBLaVh1uUQJ7qxFGCZgMttsBJKhXM9hbpFp83gmrUxYJLLE"});
+        keyPairs.add(new String[]{"5JM4fskPtJSwCqSb8Ax6vSYYRr7HwyrpnBxwfG3qr5mUFpMwgkA", "PUB_K1_77DjPHQtPRwXZKDtVvV93PsytUgevbqdPQcZpdPt2MwR541nX2"});
+        keyPairs.add(new String[]{"5K8EvWwTbQj7anhLWfr1K1mSMi78CD8YqHquei1gntJDStV8Zdh", "PUB_K1_8B89xwYNkcEEcwyC66LPptRAspCZ7SXy59BqsyoFeNyyq1sKfc"});
+        keyPairs.add(new String[]{"5J5DhKFZZqkNkTunWWbgrJNLDwZiK1vJk8Rd8nNL2fKPzLScn1x", "PUB_K1_58aKDkGmkHfswooj8nwhtrc42QrHVzUurnrhDR4Jr1rEk5uXRs"});
 
         for (String[] keyPair : keyPairs) {
-            this.signTransactionTestWithArgs(keyPair[0], keyPair[1], false);
+            this.signTransactionTestWithArgs(keyPair[0], keyPair[1]);
         }
     }
 
-    private void signTransactionTestWithArgs(String privateKey, String publicKey, boolean isLegacy) {
+    private void signTransactionTestWithArgs(String privateKey, String publicKey) {
         String serializedTransaction = "8BC2A35CF56E6CC25F7F000000000100A6823403EA3055000000572D3CCDCD01000000000000C03400000000A8ED32322A000000000000C034000000000000A682A08601000000000004454F530000000009536F6D657468696E6700";
         List<String> publicKeys = Collections.singletonList(publicKey);
         String chainId = "687fa513e18843ad3e820744f4ffcf93b1354036d80737db8dc444fe4b15ad17";
         EosioTransactionSignatureRequest request = new EosioTransactionSignatureRequest(serializedTransaction, publicKeys, chainId, null, false);
         SoftKeySignatureProviderImpl provider = new SoftKeySignatureProviderImpl();
-        provider.setReturnLegacyFormatForK1(isLegacy);
+
         try {
             provider.importKey(privateKey);
         } catch (ImportKeyError importKeyError) {
@@ -471,6 +454,24 @@ public class SoftKeySignatureProviderImplTest {
         }
 
         provider.signTransaction(request);
+    }
+
+    @Test
+    public void getAvailableKeyK1_thenFailKeyAmountIsNot1() {
+        String privateKeyEOS = "5JKVeYzRs42DpnHU1rUeJHPZyXb1pCdhyayx7FD2qKHV63F71zU";
+        SoftKeySignatureProviderImpl provider = new SoftKeySignatureProviderImpl();
+
+        try {
+            provider.importKey(privateKeyEOS);
+            List<String> keys = provider.getAvailableKeys();
+            assertNotEquals(1, keys.size());
+        } catch (ImportKeyError importKeyError) {
+            importKeyError.printStackTrace();
+            fail("Should not throw error!!!!");
+        } catch (GetAvailableKeysError getAvailableKeysError) {
+            getAvailableKeysError.printStackTrace();
+            fail("Should not throw error!!!");
+        }
     }
 
     //endregion


### PR DESCRIPTION
This is the fix for [Enhance sanity check for keys returned from getRequiredKey](https://github.com/EOSIO/eosio-java/issues/83).
The solution is quite different with initial thought. Instead of remove or change the sanity check of eosio-java. It could be done by signature provider side by: replacing legacy key setting by return both format of SECP256K1 public key (EOS and PUB_K1_) on getAvailableKe(). the Sanity check of eosio-java now could validate the subset from get_required_keys correctly. 